### PR TITLE
fix: DB 모듈 ESM 기반으로 수정

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 node_modules/
 /generated/prisma
 .env
+prisma/migrations/*

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -6,7 +6,7 @@
 
 generator client {
   provider = "prisma-client-js"
-  output   = "../generated/prisma"
+  //output   = "../generated/prisma"
 }
 
 datasource db {

--- a/src/config/db.js
+++ b/src/config/db.js
@@ -1,5 +1,5 @@
-var Prisma = require('@prisma/client');
+import { PrismaClient } from '@prisma/client';
 
-var db = new Prisma.PrismaClient();
+const db = new PrismaClient();
 
-module.exports = { db };
+export default db;


### PR DESCRIPTION

## 변경 내용
* db.js 모듈을 esm 방식으로 수정

* schema.prisma 에서 output 부분  주석 처리

* .gitignore 에 prisma/migrations/* 추가

## 이유
* 프로젝트 모듈 기본 형식인 esm 에 맞춰서 모듈 방식 통일

* esm 기반일 경우 node_modules 에 생성 되어야만 인식 하는  이슈  
  내부적으로 모듈을 불러오는 방식에서 cjs 와 esm 이 달라서 경로 이슈가 있었습니다.   
  케이스 바이 케이스로 발생하는 이슈였어서 확정적으로 해당 이슈가 발생하지 않는 해결책을 사용했습니다.
   
  ```js
  //output   = "../generated/prisma"
  ```

  기존 generated/prisma 가 아닌 node_modules 안에 생성되도록 변경했습니다.

  .gitignore 에 이미 node_modules 가 있으므로 git 에 올라가지 않는 조건도 유지합니다.
  
* 개인별 prisma migrate dev 를 했을 경우 충돌 방지
  schema.primsa 파일이 변경되면서 경우에 따라서는 prisma 마이그레이션을 다시 진행 해야 할 수 있습니다.

  그래서 만약 이 마이그레이션 파일들이 사람마다 다르게 이름이 지어지거나 하면 충돌 할 수도 있다고 예상되어서  .gitignore 에 해당 부분을 추가했습니다.

## 참고사항
* DB 마이그레이션 초기화 필요할 수 있음
  ```shell
  npx prisma migrate reset
  ```  

* 관련 이슈: #32
