### PR TITLE
feat: 태그 목록 API 구현

### DIFF
--- a/src/controllers/tag-controllers.js
+++ b/src/controllers/tag-controllers.js
@@ -1,0 +1,14 @@
+import { getTagList } from '../services/tag-services.js';
+
+export const handleGetTagList = async (_req, res, next) => {
+  try {
+    const tagList = await getTagList();
+
+    res.status(200).json({
+      success: true,
+      data: tagList,
+    });
+  } catch (error) {
+    next(error);
+  }
+};

--- a/src/routes/tag-routers.js
+++ b/src/routes/tag-routers.js
@@ -1,0 +1,8 @@
+import express from 'express';
+import { handleGetTagList } from '../controllers/tag-controllers.js';
+
+const tagRouter = express.Router();
+
+tagRouter.get('/', handleGetTagList);
+
+export default tagRouter;

--- a/src/server.js
+++ b/src/server.js
@@ -2,6 +2,7 @@ import express from 'express';
 import morgan from 'morgan';
 import cors from 'cors';
 import errorHandler from './middlewares/error-middleware.js';
+import tagRouter from './routes/tag-routers.js';
 
 export default class Server {
   #app;
@@ -24,7 +25,9 @@ export default class Server {
 
   // 라우터 등록
   // this.#app.use('/api/users', userRouter);
-  #initializeRouters() {}
+  #initializeRouters() {
+    this.#app.use('/tags', tagRouter);
+  }
 
   // 에러 핸들러 등록
   // this.#app.use(errorHandler);

--- a/src/services/tag-services.js
+++ b/src/services/tag-services.js
@@ -1,0 +1,14 @@
+import db from '../config/db.js';
+
+export const getTagList = async () => {
+  // 태그 목록
+  const tagList = await db.tag.findMany();
+
+  // 태그 목록의 총 갯수
+  const totalCount = await db.tag.count();
+
+  return {
+    totalCount: totalCount,
+    list: tagList,
+  };
+};


### PR DESCRIPTION
## 변경 내용
* tagRouter(tag-routers.js) 추가

* handleGetTagList(tag-controllers.js) 추가

* getTagList(tag-services.js) 추가

* server.js 에 tagRouter 추가

## 이유
* [코드 컨벤션](https://github.com/gyunam-bark/nb02-how-do-i-look-team1/wiki/%5B%EA%B0%9C%EB%B0%9C%EA%B7%9C%EC%B9%99%5D%EC%BD%94%EB%93%9C-%EC%BB%A8%EB%B2%A4%EC%85%98) 의 파일\/폴더 항목에 따라서 파일명을 정리했습니다.

* 현재 Tag API 명세서에는 GET 만 있습니다.  
  차후, 필요에 따라 POST 나 기타 API 가 필요에 따라 추가됩니다.

* server.js 에 tagRouter 를 사용하도록 추가했습니다.

* getTagList  는 별도의 try{}catch(e){} 를 사용하지 않았습니다.  
  db(PrismaClient) 내부에서 데이터베이스 처리가 실패할 경우 에러를 던지는 코드가 포함되어있기 때문입니다.  
  다만, 팀 내에서 좀 더 가시성을 높이기 위해서 별도의 메세지 처리(예:  TAG 데이터베이스 오류: error.message) 를 한다면 논의가 필요할 듯 싶습니다.

## 참고사항
* 관련 이슈: #14
