### PR TITLE
feat: DEV 브랜치에 pr-to-discord.yml 추가

### DIFF
--- a/.github/workflows/pr-to-discord.yml
+++ b/.github/workflows/pr-to-discord.yml
@@ -1,0 +1,69 @@
+name: Notify Reviewers on PR
+
+on:
+  workflow_dispatch: # 수동 실행 허용 (테스트용)
+  pull_request:
+    types: [opened, reopened, ready_for_review]
+
+jobs:
+  notify-discord:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Get PR reviewers
+        id: reviewers
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          PR_NUMBER="${{ github.event.pull_request.number }}"
+          REPO="${{ github.repository }}"
+
+          echo "Fetching reviewers for PR #$PR_NUMBER from $REPO"
+
+          # GitHub API 호출 및 예외 처리
+          API_RESPONSE=$(gh api repos/$REPO/pulls/$PR_NUMBER 2>/dev/null || echo "")
+
+          if [ -z "$API_RESPONSE" ]; then
+            echo "No response from GitHub API, assuming no reviewers"
+            REVIEWERS="[]"
+          else
+            REVIEWERS=$(echo "$API_RESPONSE" | jq -c '[.requested_reviewers[].login] // []')
+          fi
+
+          echo "Reviewers JSON: $REVIEWERS"
+          echo "reviewers=$REVIEWERS" >> $GITHUB_OUTPUT
+
+      - name: Notify Discord
+        env:
+          DISCORD_WEBHOOK_URL: ${{ secrets.DISCORD_WEBHOOK_URL }}
+          USER_MAP: ${{ secrets.USER_MAP }}
+        run: |
+          PR_TITLE="${{ github.event.pull_request.title }}"
+          PR_URL="${{ github.event.pull_request.html_url }}"
+          REVIEWERS=${{ steps.reviewers.outputs.reviewers }}
+
+          echo "Notifying Discord about PR: $PR_TITLE"
+          echo "Reviewers to mention: $REVIEWERS"
+
+          MENTION_LIST=""
+
+          for user in $(echo "$REVIEWERS" | jq -r '.[]'); do
+            DISCORD_ID=$(echo "$USER_MAP" | jq -r --arg u "$user" '.[$u] // empty')
+            if [ -n "$DISCORD_ID" ]; then
+              MENTION_LIST="$MENTION_LIST <@$DISCORD_ID>"
+            else
+              MENTION_LIST="$MENTION_LIST @$user"
+            fi
+          done
+
+          if [ -z "$MENTION_LIST" ]; then
+            MENTION_LIST="(리뷰어가 지정되지 않았습니다)"
+          fi
+
+          curl -X POST "$DISCORD_WEBHOOK_URL" \
+            -H "Content-Type: application/json" \
+            -d @- <<EOF
+          {
+            "content": "${MENTION_LIST}\n새로운 Pull Request: **${PR_TITLE}**\n${PR_URL}"
+          }
+          EOF


### PR DESCRIPTION
## 변경 내용
* dev 브랜치에 pr-to-discord.yml 추가

* github secret 으로 사용자명 : 디스코드ID 맵핑

## 이유
* pr-to-discord.yml 이 소속되어 있는 브랜치의 정보를 discord 로 보냄  
  기존에는 pr-to-discord.yml 이 main 에만 있었습니다.   
  dev 에도 pr-to-discord.yml 을 추가해서 task-{id} 의 머지들이 dev 로 메세지를 보내질 수 있도록 수정 했습니다.

* github secret 에 사용자 명과 디스코드ID를 json 형태로 맵핑했습니다.

## 참고사항
* pr 로 테스트 필요.
* 관련 이슈: #40
