### PR TITLE
refactor(prisma): Image 모델에서 styleId 제거 및 StyleImage 조인 테이블 추가

### DIFF
--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -25,11 +25,11 @@ model Style {
   createdAt     DateTime @default(now())
   updatedAt     DateTime @updatedAt
 
-  curations  Curation[]
-  categories Category[]
-  comments   Comment[]
-  images     Image[]
-  styleTags  StyleTag[] // 연결고리
+  curations   Curation[]
+  categories  Category[]
+  comments    Comment[]
+  styleImages StyleImage[]
+  styleTags   StyleTag[] // 연결고리
 }
 
 model Curation {
@@ -84,11 +84,21 @@ enum CategoryType {
 }
 
 model Image {
-  imageId  Int    @id @default(autoincrement())
-  styleId  Int
-  imageUrl String
+  imageId     Int          @id @default(autoincrement())
+  imageUrl    String
+  createdAt   DateTime     @default(now()) // 업로드 시점 저장용 
+  styleImages StyleImage[]
+}
+
+// 중간 테이블
+model StyleImage {
+  styleId Int
+  imageId Int
 
   style Style @relation(fields: [styleId], references: [styleId])
+  image Image @relation(fields: [imageId], references: [imageId])
+
+  @@id([styleId, imageId]) // 복합 PK
 }
 
 model Tag {


### PR DESCRIPTION
<h3> 변경 내용 </h3>
1. 기존 Image 테이블에서 styleId 외래 키 필드 제거 </br>
2. Style과 Image 간의 관계를 다대다(M:N) 로 변경하고, 중간 연결 테이블 StyleImage 추가 </br>
3. 추후 스타일 등록 시 imageIds[]를 함께 받아, StyleImage 테이블을 통해 연관된 이미지 연결이 가능하도록 구조 설계 </br>

<h3> 변경 이유 </h3>
스타일을 등록할 때 이미지는 필수이지만, 이미지 업로드 시에는 styleId가 필요하지 않습니다. </br>
하지만 현재 Prisma 모델에서는 Image가 Style을 직접 참조하고 있어서 이미지 업로드 시점에 styleId가 없으면 저장 할 수 없는 구조적 문제가 있었습니다. 이를 해결하기 위해, Style과 Image 간의 관계를 다대다(M:N)로 재정의하고, 중간 연결 테이블(StyleImage)을 통해 연결되도록 설계를 변경했습니다. </br> 
따라서 </br> 
- 이미지 업로드는 styleId 없이 독립적으로 가능하고 </br> 
- 하나의 스타일에 여러 이미지를 연결하거나, </br> 
- 하나의 이미지를 여러 스타일에서 참조하는 유연한 구조가 됩니다. </br> 
</br>
Prisma 모델에서는 참조 방향을 Style → Image로만 구성하여, 스타일 등록 시에만 연결이 일어나도록 일방향 참조 형태로 설정했습니다.
이 구조는 이미지 리소스를 독립적으로 관리할 수 있는 장점이 있습니다. 