### PR TITLE
fix: 답글 라우터 위치 정리 및 구조 통일

### DIFF
--- a/src/routes/comment-routes.js
+++ b/src/routes/comment-routes.js
@@ -2,10 +2,9 @@ import express from 'express';
 
 const router = express.Router();
 
-import { createComment, updateComment, deleteComment } from '../controllers/comment-controllers.js';
+import { updateComment, deleteComment } from '../controllers/comment-controllers.js';
 
-router.post('/curations/:id/comments', createComment); // 댓글 등록
-router.put('/comments/:id', updateComment); // 댓글 수정
-router.delete('/comments/:id', deleteComment); // 댓글 삭제
+router.put('/:commentId', updateComment); // 답글 수정
+router.delete('/:commentId', deleteComment); // 답글 삭제
 
 export default router;

--- a/src/routes/curation-routes.js
+++ b/src/routes/curation-routes.js
@@ -1,5 +1,6 @@
 import { Router } from 'express';
 import { CurationController } from '../controllers/curation-controller.js';
+import { createComment } from '../controllers/comment-controllers.js';
 
 const router = Router();
 
@@ -7,5 +8,6 @@ router.post('/styles/:styleId', CurationController.createCuration); //큐레이�
 router.put('/:curationId', CurationController.updateCuration); //큐레이팅 수정
 router.delete('/:curationId', CurationController.deleteCuration); //큐레이팅 삭제
 
+router.post('/:curationId/comments', createComment); // 답글 등록
 
 export default router;

--- a/src/server.js
+++ b/src/server.js
@@ -7,7 +7,7 @@ import styleRouter from './routes/style-routes.js';
 
 import curationRouter from './routes/curation-routes.js';
 import imageRouter from './routes/image-route.js';
-import comment from './routes/comment-routes.js';
+import commentRouter from './routes/comment-routes.js';
 import tagRouter from './routes/tag-routers.js';
 import rankRouter from './routes/rank-route.js';
 
@@ -53,7 +53,7 @@ export default class Server {
     this.#app.use('/tags', tagRouter);
     this.#app.use('/styles', styleRouter);
     this.#app.use('/curations', curationRouter);
-    this.#app.use(comment);
+    this.#app.use('/comments', commentRouter);
   }
 
   // 에러 핸들러 등록

--- a/src/services/comment-services.js
+++ b/src/services/comment-services.js
@@ -3,7 +3,7 @@ import db from '../config/db.js';
 // 답글 등록
 export const createCommentService = async (req, _res, _next) => {
   const { password, content } = req.body;
-  const curationId = Number(req.params.id);
+  const curationId = Number(req.params.curationId);
 
   // style 비밀번호를 참조하기위해 stlye을 포함시킵니다.
   const curation = await db.curation.findUnique({
@@ -50,11 +50,11 @@ export const createCommentService = async (req, _res, _next) => {
 // 답글 수정
 export const updateCommentService = async (req, _res, _next) => {
   const { content, password } = req.body;
-  const curationId = Number(req.params.id);
+  const commentId = Number(req.params.commentId);
 
   // 닉네임을 가져오기위해 style을 포함시킵니다.
   const comment = await db.comment.findFirst({
-    where: { curationId },
+    where: { commentId },
     include: {
       curation: {
         include: { style: true },
@@ -88,10 +88,10 @@ export const updateCommentService = async (req, _res, _next) => {
 // 답글 삭제
 export const deleteCommentService = async (req, _res, _next) => {
   const { password } = req.body;
-  const curationId = Number(req.params.id);
+  const commentId = Number(req.params.commentId);
 
   const comment = await db.comment.findFirst({
-    where: { curationId },
+    where: { commentId },
   });
 
   if (!comment) {


### PR DESCRIPTION
## 변경 내용

- 답글등록의 라우터 위치를 큐레이션 라우터로 옮기고 파라미터 변수명을 명세서를 참고하여 통일시켰습니다.

## 이유

- 명세서에 나와있는 URL 구조를 사용하기 위해서 변경했습니다.

## 참고사항

- 관련 이슈: #109 
