### PR TITLE
fix: Style FE 에 맞춰서 DTO 제한 사항 부분 수정

### DIFF
--- a/src/middlewares/dto-middleware.js
+++ b/src/middlewares/dto-middleware.js
@@ -28,11 +28,11 @@ const RANK_BY_ENUMS = {
   PRACTICALITY: 'practicality',
   COST_EFFECTIVENESS: 'costEffectiveness',
 };
-const KEYWORD_MIN = 1;
+const KEYWORD_MIN = 0;
 const KEYWORD_MAX = 32;
 const NICKNAME_MIN = 1;
 const NICKNAME_MAX = 32;
-const TAG_MIN = 1;
+const TAG_MIN = 0;
 const TAG_MAX = 16;
 const TITLE_MIN = 1;
 const TITLE_MAX = 64;


### PR DESCRIPTION
## 변경 내용

- KEYWORD_MIN = 0; 으로 수정되었습니다.

## 이유

- FE 를 실행했을 때 쿼리로 keyword= 와 같이 비워져서 보내지는 것을 확인했습니다.

## 참고사항
- 그 밖에 /styles 에서 쿼리를 보낼 때 빈 값으로 보내지는 경우가 있는지 확인이 필요합니다.
  FE 연동 작업하다 보면 자연스레 에러가 발생해서 확인할 수 있습니다.
- 관련 이슈: #143
