### PR TITLE
fix: package.json 에서 jsonwebtoken 제거

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14,7 +14,6 @@
         "dotenv": "^16.5.0",
         "express": "^5.1.0",
         "firebase-admin": "^13.4.0",
-        "jsonwebtoken": "^9.0.2",
         "morgan": "^1.10.0",
         "multer": "^2.0.0",
         "superstruct": "^2.0.2"

--- a/package.json
+++ b/package.json
@@ -32,7 +32,6 @@
     "dotenv": "^16.5.0",
     "express": "^5.1.0",
     "firebase-admin": "^13.4.0",
-    "jsonwebtoken": "^9.0.2",
     "morgan": "^1.10.0",
     "multer": "^2.0.0",
     "superstruct": "^2.0.2"


### PR DESCRIPTION
## 변경 내용

- package.json 에서 jsonwebtoken 제거
  
  ```bash
  npm uninstall jsonwebtoken
  ```

## 이유

- jsonwebtoken 이 사용되지 않는 것을 확인했습니다. 불필요한 패키지 제거 합니다.

## 참고사항

- 관련 이슈: #150
