### PR TITLE
feat: 스타일 및 큐레이션 API 수정

### DIFF
--- a/src/controllers/curation-controller.js
+++ b/src/controllers/curation-controller.js
@@ -2,55 +2,11 @@ import { PrismaClient } from '@prisma/client';
 const prisma = new PrismaClient();
 
 import {
-  createCurationService,
-  getCurationListService,
   updateCurationService,
   deleteCurationService,
 } from '../services/curation-service.js';
 
 export class CurationController {
-  // 큐레이팅 등록 (POST /curations/styles/:styleId)
-  static async createCuration(req, res, next) {
-    try {
-      const { styleId } = req.params;
-      const { nickname, password, trendy, personality, practicality, costEffectiveness, content } = req.body;
-
-      const newCurationData = await createCurationService({
-        styleId,
-        nickname,
-        password,
-        trendy,
-        personality,
-        practicality,
-        costEffectiveness,
-        content,
-      });
-
-      res.status(201).json(newCurationData);
-    } catch (err) {
-      next(err);
-    }
-  }
-
-  // 큐레이팅 목록 조회 (GET /curations/styles/:styleId)
-  static async getCurationList(req, res, next) {
-    try {
-      const { styleId } = req.params;
-      const { page, pageSize, searchBy, keyword } = req.query;
-
-      const curationsData = await getCurationListService({
-        styleId,
-        page,
-        pageSize,
-        searchBy,
-        keyword,
-      });
-
-      res.status(200).json(curationsData);
-    } catch (err) {
-      next(err);
-    }
-  }
 
   // 큐레이팅 수정 (PUT /curations/:curationId)
   static async updateCuration(req, res, next) {
@@ -70,6 +26,12 @@ export class CurationController {
 
       res.status(200).json(updatedCurationData);
     } catch (err) {
+      if (err.message === '큐레이팅을 찾을 수 없습니다.') {
+        return res.status(404).json({ message: err.message });
+      }
+      if (err.message === '비밀번호가 일치하지 않습니다.') {
+        return res.status(403).json({ message: err.message });
+      }
       next(err);
     }
   }
@@ -84,6 +46,12 @@ export class CurationController {
 
       res.status(200).json(result);
     } catch (err) {
+      if (err.message === '큐레이팅을 찾을 수 없습니다.') {
+        return res.status(404).json({ message: err.message });
+      }
+      if (err.message === '비밀번호가 일치하지 않습니다.') {
+        return res.status(403).json({ message: err.message });
+      }
       next(err);
     }
   }

--- a/src/controllers/style-controller.js
+++ b/src/controllers/style-controller.js
@@ -275,4 +275,56 @@ export class StyleController {
       next(err);
     }
   }
-}
+  
+  static async createCuration(req, res, next) {
+    try {
+      const { styleId } = req.params;
+      const { nickname, password, trendy, personality, practicality, costEffectiveness, content } = req.body;
+
+      // 서비스 함수 호출
+      const newCuration = await createCurationForStyle({
+        styleId: +styleId, 
+        nickname,
+        password,
+        trendy,
+        personality,
+        practicality,
+        costEffectiveness,
+        content,
+      });
+
+      res.status(201).json(newCuration); 
+    } catch (err) {
+      if (err.message === '스타일을 찾을 수 없습니다.') {
+        return res.status(404).json({ message: err.message });
+      }
+      next(err);
+    }
+  }
+
+  // 스타일에 대한 큐레이션 목록 조회 (GET /styles/:styleId/curations)
+  static async getCurationList(req, res, next) {
+    try {
+      const { styleId } = req.params;
+      const { page, pageSize, searchBy, keyword } = req.query;
+
+      const curationsData = await getCurationListForStyle({
+        styleId: +styleId,
+        page,
+        pageSize,
+        searchBy,
+        keyword,
+      });
+
+      res.status(200).json(curationsData); 
+    } catch (err) {
+      if (err.message === '페이지 및 페이지 크기는 1 이상의 유효한 숫자여야 합니다.' || err.message === '유효하지 않은 검색 기준입니다.') {
+        return res.status(400).json({ message: err.message });
+      }
+      if (err.message === '스타일을 찾을 수 없습니다.') {
+        return res.status(404).json({ message: err.message });
+      }
+      next(err);
+    }
+  }
+}  

--- a/src/middlewares/dto-middleware.js
+++ b/src/middlewares/dto-middleware.js
@@ -157,7 +157,14 @@ export const getStyleListSchema = {
 };
 // PUT:STYLE
 export const updateStyleSchema = {
-  body: object({}),
+  body: object({
+    password: password,
+    title: optional(title),
+    content: optional(content),
+    categories: optional(categories),
+    tags: optional(tags),
+    imageUrls: optional(imageUrls), 
+  }),
   query: object({}),
   params: object({
     styleId: id,
@@ -165,7 +172,9 @@ export const updateStyleSchema = {
 };
 // DELETE:STYLE
 export const deleteStyleSchema = {
-  body: object({}),
+  body: object({
+    password: password,
+  }),
   query: object({}),
   params: object({
     styleId: id,

--- a/src/routes/curation-routes.js
+++ b/src/routes/curation-routes.js
@@ -5,9 +5,8 @@ import { validateRequest, createCommentSchema } from '../middlewares/dto-middlew
 
 const router = Router();
 
-router.post('/styles/:styleId', CurationController.createCuration); //큐레이팅 등록
-router.put('/:curationId', CurationController.updateCuration); //큐레이팅 수정
-router.delete('/:curationId', CurationController.deleteCuration); //큐레이팅 삭제
+router.put('/:curationId', CurationController.updateCuration); //큐레이션 수정
+router.delete('/:curationId', CurationController.deleteCuration); //큐레이션 삭제
 
 router.post('/:curationId/comments', validateRequest(createCommentSchema), CommentController.createComment); // 답글 등록
 

--- a/src/routes/style-route.js
+++ b/src/routes/style-route.js
@@ -6,7 +6,9 @@ import {
   getStyleListSchema,
   getStyleDetailSchema,
   updateStyleSchema,
-  deleteStyleSchema
+  deleteStyleSchema,
+  createCurationSchema, 
+  getCurationListSchema
 } from '../middlewares/dto-middleware.js';
 
 const router = Router();
@@ -16,6 +18,9 @@ router.get('/', validateRequest(getStyleListSchema), StyleController.getStyleLis
 router.get('/:styleId', validateRequest(getStyleDetailSchema), StyleController.getStyleDetail);   // 상세
 router.put('/:styleId', validateRequest(updateStyleSchema), StyleController.updateStyle);          // 수정
 router.delete('/:styleId', validateRequest(deleteStyleSchema), StyleController.deleteStyle);       // 삭제
+
+router.post('/:styleId/curations', validateRequest(createCurationSchema), StyleController.createCuration);
+router.get('/:styleId/curations', validateRequest(getCurationListSchema), StyleController.getCurationList);
 
 export default router;
 

--- a/src/services/style-service.js
+++ b/src/services/style-service.js
@@ -92,3 +92,97 @@ export const deleteStyle = async (styleId) => {
   await db.style.delete({ where: { styleId: +styleId } });
   return { message: '스타일이 삭제되었습니다.' };
 };
+
+export const createCuration = async ({ styleId, nickname, password, trendy, personality, practicality, costEffectiveness, content }) => {
+  const existingStyle = await db.style.findUnique({
+    where: { styleId: +styleId },
+  });
+  if (!existingStyle) {
+    throw new Error('스타일을 찾을 수 없습니다.');
+  }
+
+  const newCuration = await db.curation.create({
+    data: {
+      styleId: +styleId,
+      nickname,
+      password: password,
+      trendy: +trendy,
+      personality: +personality,
+      practicality: +practicality,
+      costEffectiveness: +costEffectiveness,
+      content: content?.trim(),
+    },
+    include: {
+      comments: true,
+      style: {
+        include: {
+          categories: true,
+          styleTags: { include: { tag: true } },
+          styleImages: { include: { image: true } },
+          _count: { select: { curations: true } },
+        },
+      },
+    },
+  });
+
+  return newCuration;
+};
+
+// 스타일의 큐레이션 목록 조회
+export const getCurationList = async ({ styleId, page, pageSize, searchBy, keyword }) => {
+  const parsedPage = parseInt(page || 1);
+  const parsedPageSize = parseInt(pageSize || 10);
+
+  if (parsedPage < 1 || parsedPageSize < 1) {
+    throw new Error('페이지 및 페이지 크기는 1 이상의 유효한 숫자여야 합니다.');
+  }
+
+  const existingStyle = await db.style.findUnique({
+    where: { styleId: +styleId },
+  });
+  if (!existingStyle) {
+    throw new Error('스타일을 찾을 수 없습니다.');
+  }
+
+  let where = { styleId: +styleId };
+  if (searchBy && keyword) {
+    if (searchBy === 'nickname') {
+      where.nickname = { contains: keyword, mode: 'insensitive' };
+    } else if (searchBy === 'content') {
+      where.content = { contains: keyword, mode: 'insensitive' };
+    } else {
+      throw new Error('유효하지 않은 검색 기준입니다.');
+    }
+  }
+
+  const [totalItemCount, curations] = await Promise.all([
+    db.curation.count({ where }),
+    db.curation.findMany({
+      where,
+      skip: (parsedPage - 1) * parsedPageSize,
+      take: parsedPageSize,
+      orderBy: { createdAt: 'desc' },
+      include: {
+        comments: true,
+        style: {
+          include: {
+            categories: true,
+            styleTags: { include: { tag: true } },
+            styleImages: { include: { image: true } },
+            _count: { select: { curations: true } },
+          },
+        },
+      },
+    }),
+  ]);
+
+  const totalPages = Math.ceil(totalItemCount / parsedPageSize);
+  const currentPage = parsedPage;
+
+  return {
+    currentPage,
+    totalPages,
+    totalItemCount,
+    data: curations,
+  };
+};


### PR DESCRIPTION
## 변경 내용

- service 
    - `style-services.js`에 스타일과 연결된 큐레이팅 생성(`createCuration`) 및 조회(`getCurationList`) 서비스 함수를 추가했습니다.
    - 각 컨트롤러 메서드 내던져지는 에러에 대한 **HTTP 상태 코드 처리**를 추가

- route
    - `src/routes/curation-routes.js`에서 `POST /styles/:styleId` 라우팅을 제거, 큐레이션 라우터는 큐레이팅 자체의 수정/삭제 만 가능하도록 수정하였습니다.
    - `src/routes/style-routes.js`에 `POST /styles/:styleId/curations` (큐레이션 등록) 및 `GET /styles/:styleId/curations` (큐레이션 목록 조회) 라우팅을 추가하여 스타일 리소스에 종속된 큐레이션 작업은 `style` 라우터가 담당하도록 명확히 했습니다.

- **DTO 수정:**
    - `src/middlewares/dto-middleware.js`에서 `updateStyleSchema` 및 `deleteStyleSchema`의 `body` 정의를 실제 컨트롤러에서 사용하는 요청 본문 필드에 맞춰 수정하여 유효성 검사 오류를 방지했습니다.

- **`src/controllers/curation-controller.js` 정리:**
    - 사용되지 않는 `createCuration` 및 `getCurationList` 메서드를 제거하였습니다.

## 이유

- 엔드포인트에 따라 각 서비스의 경로에서 해야할 역할 정리
- 팀코드 스타일의 일관성을 위해 일부 코드를 수정하였습니다.
- StyleController의 updateStyle 및 deleteStyle 메서드는 요청 본문(body)에서 password, title, content, categories, tags, images 등의 데이터를 추출하여 사용하고 있지만, updateStyleSchema와 deleteStyleSchema는 body: object({ })로 정의되어 있어 본문이 비어 있을 수도 있다 생각하여 수정하였습니다.

## 참고사항

- 관련 이슈: #112