### PR TITLE
fix: error-middleware db 객체 선언/import 추가

### DIFF
--- a/src/middlewares/error-middleware.js
+++ b/src/middlewares/error-middleware.js
@@ -1,4 +1,6 @@
-import db from '../config/db.js';
+import { PrismaClient } from '@prisma/client';
+const db = new PrismaClient();
+
 
 // 상태 코드에 따른 메시지 정의 객체
 // API 명세서에 정의된 상태 코드(400, 403, 404)


### PR DESCRIPTION
## 변경 내용

- db 객체 선언/import 내용이 없어 추가 하였습니다.

## 이유

- style API 테스트 중 목록조회에서 error 발생으로 원인 분석하다 db 객체 선언/import 내용이 없는 것이 발견되어 추가합니다.

## 참고사항

- 관련 이슈: #158 
