### PR TITLE
fix: FE에 맞춰서 logId 를 id 로 보내도록 수정

### DIFF
--- a/src/middlewares/dto-middleware.js
+++ b/src/middlewares/dto-middleware.js
@@ -26,6 +26,7 @@ const SEARCH_BY_CURATION_ENUMS = {
   CONTENT: 'content',
 };
 const SEARCH_BY_LOG_ENUMS = {
+  IP: 'ip',
   MESSAGE: 'message',
   METHOD: 'method',
   ENDPOINT: 'endpoint',
@@ -163,7 +164,7 @@ export const updateStyleSchema = {
     content: optional(content),
     categories: optional(categories),
     tags: optional(tags),
-    imageUrls: optional(imageUrls), 
+    imageUrls: optional(imageUrls),
   }),
   query: object({}),
   params: object({
@@ -342,4 +343,6 @@ export default {
   createCommentSchema,
   updateCommentSchema,
   deleteCommentSchema,
+  // LOG
+  getLogListSchema,
 };

--- a/src/services/log-service.js
+++ b/src/services/log-service.js
@@ -77,9 +77,14 @@ export default class LogService {
       }),
     ]);
 
+    const fixedLogList = logList.map(({ logId, ...other }) => ({
+      id: logId,
+      ...other,
+    }));
+
     return {
       totalItemCount: totalItemCount,
-      data: logList,
+      data: fixedLogList,
     };
   };
 }


### PR DESCRIPTION
## 변경 내용

- dto-middleware.js 에 SearchBy 누락된 키워드 ip 추가
- FE 에서 객체 본인의 id 는 id 로 쓰기 때문에 그것에 맞춰서 보내도록 수정

## 이유

- FE 에러 방지

## 참고사항

- 관련 이슈: #161
