### PR TITLE
style 응답을 API 명세서 형식에 맞게 수정

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,8 @@
   },
   "main": "index.js",
   "prisma": {
-  "seed": "node prisma/seed.js"},
+    "seed": "node prisma/seed.js"
+  },
   "scripts": {
     "reset": "npx prisma migrate reset -f",
     "migrate": "npx prisma migrate dev",

--- a/src/middlewares/dto-middleware.js
+++ b/src/middlewares/dto-middleware.js
@@ -159,6 +159,7 @@ export const getStyleListSchema = {
 // PUT:STYLE
 export const updateStyleSchema = {
   body: object({
+    nickname: optional(nickname),
     password: password,
     title: optional(title),
     content: optional(content),


### PR DESCRIPTION
## 변경 내용

- style 응답을 API 명세서 형식에 맞게 수정
-  이미지 등록 시 imageUrl도 함께 저장되도록 createImagesAndReturnIds 로직 수정
- imageUrls가 응답에 포함되어 클라이언트에서 이미지 미리보기 가능
- 스타일 수정 시 nickname 필드 누락되어 반영되지 않던 문제 수정 
- dto-middleware의 updateStyleSchema에 nickname 필드 추가

## 이유

- 스타일 등록/수정 관련해서 이미지가 등록돼도 응답에 나타나지 않거나 닉네임이 반영되지 않던 이슈를 수정했습니다.

## 참고사항

- 관련 이슈: #176 
