### PR TITLE
feat: /docs 스웨거 엔드포인트 추가

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,11 +1,13 @@
-
 // 서버 실행
 
 import dotenv from 'dotenv';
 import Server from './src/server.js';
+import { readSwaggerJson } from './src/middlewares/swagger-middleware.js';
 
 const main = async () => {
   dotenv.config();
+
+  await readSwaggerJson();
 
   const server = new Server();
   server.run();

--- a/openapi.json
+++ b/openapi.json
@@ -1,0 +1,44 @@
+{
+  "openapi": "3.0.0",
+  "info": {
+    "title": "HOW DO I LOOK API",
+    "version": "1.0.0",
+    "description": "Swagger for HOW DO I LOOK"
+  },
+  "servers": [
+    {
+      "url": "http://localhost:3001",
+      "description": "Local server"
+    }
+  ],
+  "paths": {
+    "/tags": {
+      "get": {
+        "summary": "Get tag list",
+        "description": "Returns a list of tags as strings",
+        "responses": {
+          "200": {
+            "description": "Successful response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "tags": {
+                      "type": "array",
+                      "items": {
+                        "type": "string"
+                      },
+                      "example": ["string", "string"]
+                    }
+                  },
+                  "required": ["tags"]
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -17,7 +17,8 @@
         "firebase-admin": "^13.4.0",
         "morgan": "^1.10.0",
         "multer": "^2.0.0",
-        "superstruct": "^2.0.2"
+        "superstruct": "^2.0.2",
+        "swagger-ui-express": "^5.0.1"
       },
       "devDependencies": {
         "eslint": "^9.28.0",
@@ -609,6 +610,13 @@
       "integrity": "sha512-Vvn3zZrhQZkkBE8LSuW3em98c0FwgO4nxzv6OdSxPKJIEKY2bGbHn+mhGIPerzI4twdxaP8/0+06HBpwf345Lw==",
       "license": "BSD-3-Clause",
       "optional": true
+    },
+    "node_modules/@scarf/scarf": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/@scarf/scarf/-/scarf-1.4.0.tgz",
+      "integrity": "sha512-xxeapPiUXdZAE3che6f3xogoJPeZgig6omHEy1rIY5WVsB3H2BHNnZH+gHG6x91SCWyQCzWGsuL2Hh3ClO5/qQ==",
+      "hasInstallScript": true,
+      "license": "Apache-2.0"
     },
     "node_modules/@tootallnate/once": {
       "version": "2.0.0",
@@ -3583,6 +3591,30 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/swagger-ui-dist": {
+      "version": "5.24.1",
+      "resolved": "https://registry.npmjs.org/swagger-ui-dist/-/swagger-ui-dist-5.24.1.tgz",
+      "integrity": "sha512-ITeWc7CCAfK53u8jnV39UNqStQZjSt+bVYtJHsOEL3vVj/WV9/8HmsF8Ej4oD8r+Xk1HpWyeW/t59r1QNeAcUQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@scarf/scarf": "=1.4.0"
+      }
+    },
+    "node_modules/swagger-ui-express": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/swagger-ui-express/-/swagger-ui-express-5.0.1.tgz",
+      "integrity": "sha512-SrNU3RiBGTLLmFU8GIJdOdanJTl4TOmT27tt3bWWHppqYmAZ6IDuEuBvMU6nZq0zLEe6b/1rACXCgLZqO6ZfrA==",
+      "license": "MIT",
+      "dependencies": {
+        "swagger-ui-dist": ">=5.0.0"
+      },
+      "engines": {
+        "node": ">= v0.10.32"
+      },
+      "peerDependencies": {
+        "express": ">=4.0.0 || >=5.0.0-beta"
       }
     },
     "node_modules/synckit": {

--- a/package.json
+++ b/package.json
@@ -38,7 +38,8 @@
     "firebase-admin": "^13.4.0",
     "morgan": "^1.10.0",
     "multer": "^2.0.0",
-    "superstruct": "^2.0.2"
+    "superstruct": "^2.0.2",
+    "swagger-ui-express": "^5.0.1"
   },
   "type": "module",
   "devDependencies": {

--- a/src/controllers/root-controller.js
+++ b/src/controllers/root-controller.js
@@ -1,0 +1,17 @@
+export default class RootController {
+  static handleHealthCheck = async (_req, res, next) => {
+    try {
+      const status = 'OK';
+      const uptime = process.uptime();
+      const timestamp = new Date().toISOString();
+      res.status(200).json({
+        status,
+        uptime,
+        timestamp,
+      });
+    } catch (error) {
+      error.statusCode = 500;
+      next(error);
+    }
+  };
+}

--- a/src/middlewares/swagger-middleware.js
+++ b/src/middlewares/swagger-middleware.js
@@ -1,0 +1,33 @@
+import swaggerUi from 'swagger-ui-express';
+import fs from 'fs/promises';
+import path from 'path';
+import { fileURLToPath } from 'url';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+const openapiPath = path.join(__dirname, '../../openapi.json');
+
+let swaggerSpec = null;
+
+export const readSwaggerJson = async () => {
+  try {
+    const raw = await fs.readFile(openapiPath, 'utf-8');
+    swaggerSpec = JSON.parse(raw);
+    console.log('swagger spec loaded');
+  } catch (error) {
+    console.error('failed to load swagger spec:', error);
+  }
+};
+
+// 정적 파일 미들웨어
+export const swaggerMiddlewareStatic = swaggerUi.serve;
+
+// 렌더링 미들웨어
+export const swaggerMiddlewareRender = (req, res, next) => {
+  if (!swaggerSpec) {
+    const error = new Error('swagger spec not loaded');
+    error.statusCode = 500;
+    return next(error);
+  }
+  return swaggerUi.setup(swaggerSpec)(req, res, next);
+};

--- a/src/routes/doc-route.js
+++ b/src/routes/doc-route.js
@@ -1,0 +1,8 @@
+import express from 'express';
+import { swaggerMiddlewareStatic, swaggerMiddlewareRender } from '../middlewares/swagger-middleware.js';
+
+const docRouter = express.Router();
+
+docRouter.use('/', swaggerMiddlewareStatic, swaggerMiddlewareRender);
+
+export default docRouter;

--- a/src/routes/root-routes.js
+++ b/src/routes/root-routes.js
@@ -1,19 +1,8 @@
 import express from 'express';
-import path from 'path';
-import { fileURLToPath } from 'url';
+import RootController from '../controllers/root-controller.js';
 
 const rootRouter = express.Router();
 
-const __filename = fileURLToPath(import.meta.url);
-const __dirname = path.dirname(__filename);
-
-rootRouter.use(express.static(path.join(__dirname, '../../public')));
-
-rootRouter
-  .route('/')
-  // API 테스터
-  .get((req, res) => {
-    res.sendFile(path.join(__dirname, '../../public', 'index.html'));
-  });
+rootRouter.get('/', RootController.handleHealthCheck);
 
 export default rootRouter;

--- a/src/server.js
+++ b/src/server.js
@@ -14,6 +14,7 @@ import errorHandler from './middlewares/error-middleware.js';
 import uploadsDir from './config/uploads-path.js';
 import rootRouter from './routes/root-routes.js';
 import logRouter from './routes/log-route.js';
+import docRouter from './routes/doc-route.js';
 
 export default class Server {
   #app;
@@ -55,6 +56,7 @@ export default class Server {
     this.#app.use('/curations', curationRouter);
     this.#app.use('/comments', commentRouter);
     this.#app.use('/logs', logRouter);
+    this.#app.use('/docs', docRouter);
   }
 
   // 에러 핸들러 등록


### PR DESCRIPTION
## 변경 내용

- /docs 스웨거 엔드포인트 추가

- / 헬스체크 엔드포인트로 수정  
  이제 서버 상태를 반환하는 헬스체크 엔드포인트로 동작합니다.
  ```js
  const status = 'OK';
  const uptime = process.uptime();
  const timestamp = new Date().toISOString();
  
  res.status(200).json({
    status,
    uptime,
    timestamp,
  });
  ```

- openapi.json 추가 

## 이유

- 스웨거 문서화를 위해서 엔드포인트를 추가했습니다.
- 기존 API 테스터가 더 이상 필요하지 않기 때문에, '/' 루트 엔드포인트는 서버 헬스체크 엔드포인트로 수정했습니다. 
- 규칙에 맞게 openapi.json 만 기입하면, 서버 시작 시 자동으로 Swagger 에 적용됩니다.

## 참고사항
- 동작 확인 후 기존 API 테스터 코드 삭제 예정
- openapi.json 작업 필요 
- 관련 이슈: #200