### PR TITLE
fix: 답글 스키마에 연쇄 삭제 설정

### DIFF
--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -56,7 +56,7 @@ model Comment {
   createdAt  DateTime @default(now())
   updatedAt  DateTime @updatedAt
 
-  curation Curation @relation(fields: [curationId], references: [curationId])
+  curation Curation @relation(fields: [curationId], references: [curationId], onDelete: Cascade)
 }
 
 model Category {


### PR DESCRIPTION
## 변경 내용

- 답글 스키마에 onDelete 설정 추가

## 이유

- 불필요한 데이터가 남지 않게 큐레이션 삭제시 답글도 일괄 삭제 되도록 추가 했습니다.

## 참고사항

- 관련 이슈: #206 
