### PR TITLE
fix: 패스워드 최소길이 8로 수정

### DIFF
--- a/src/middlewares/dto-middleware.js
+++ b/src/middlewares/dto-middleware.js
@@ -63,7 +63,7 @@ const TITLE_MIN = 1;
 const TITLE_MAX = 64;
 const CONTENT_MIN = 1;
 const CONTENT_MAX = 256;
-const PASSWORD_MIN = 4;
+const PASSWORD_MIN = 8;
 const PASSWORD_MAX = 16;
 const NAME_MIN = 1;
 const NAME_MAX = 64;
@@ -348,7 +348,7 @@ export const validateRequest = (schema = {}) => {
       // NEXT TO CONTROLLER
       next();
     } catch (error) {
-      console.log('🟥 validateRequest error:', error); 
+      console.log('🟥 validateRequest error:', error);
       if (error instanceof StructError) {
         error.statusCode = 400;
         error.message = undefined;


### PR DESCRIPTION
## 변경 내용

- 패스워드 최소길이 8로 수정

## 이유

- 프론트엔드 연동 버그 수정

## 참고사항

- 관련 이슈: #214
