### PR TITLE
fix 큐레이팅 API 유효성 및 암호화 로직 개선

### DIFF
--- a/src/controllers/curation-controller.js
+++ b/src/controllers/curation-controller.js
@@ -1,14 +1,12 @@
-import { PrismaClient } from '@prisma/client';
-const prisma = new PrismaClient();
-
 import { updateCurationService, deleteCurationService } from '../services/curation-service.js';
+
 
 export class CurationController {
   // 큐레이팅 수정 (PUT /curations/:curationId)
   static async updateCuration(req, res, next) {
     try {
-      const { curationId } = req.params;
-      const { password, trendy, personality, practicality, costEffectiveness, content, nickname } = req.body;
+      const { curationId } = req.validated.params;
+      const { password, trendy, personality, practicality, costEffectiveness, content, nickname } = req.validated.body;
 
       const updatedCurationData = await updateCurationService(curationId, {
         password,
@@ -47,8 +45,8 @@ export class CurationController {
   // 큐레이팅 삭제 (DELETE /curations/:curationId)
   static async deleteCuration(req, res, next) {
     try {
-      const { curationId } = req.params;
-      const { password } = req.body;
+      const { curationId } = req.validated.params;
+      const { password } = req.validated.body;
 
       const result = await deleteCurationService(curationId, password);
 

--- a/src/controllers/style-controller.js
+++ b/src/controllers/style-controller.js
@@ -333,11 +333,12 @@ export class StyleController {
       next(err);
     }
   }
+  
   // 스타일에 대한 큐레이션 생성 (POST /styles/:styleId/curations)
   static async createCuration(req, res, next) {
     try {
-      const { styleId } = req.params;
-      const { nickname, password, trendy, personality, practicality, costEffectiveness, content } = req.body;
+      const { styleId } = req.validated.params
+      const { nickname, password, trendy, personality, practicality, costEffectiveness, content } = req.validated.body
 
       // 서비스 함수 호출
       const newCuration = await createCurationForStyle({
@@ -377,8 +378,8 @@ export class StyleController {
   // 스타일에 대한 큐레이션 목록 조회 (GET /styles/:styleId/curations)
   static async getCurationList(req, res, next) {
     try {
-      const { styleId } = req.params;
-      const { page, pageSize, searchBy, keyword } = req.query;
+      const { styleId } = req.validated.params;
+      const { page, pageSize, searchBy, keyword } = req.validated.query;
 
       const curationsData = await getCurationList({
         styleId: +styleId,

--- a/src/routes/curation-routes.js
+++ b/src/routes/curation-routes.js
@@ -5,8 +5,8 @@ import { validateRequest, createCommentSchema } from '../middlewares/dto-middlew
 
 const router = Router();
 
-router.put('/:curationId', CurationController.updateCuration); //큐레이션 수정
-router.delete('/:curationId', CurationController.deleteCuration); //큐레이션 삭제
+router.put('/:curationId', validateRequest(updateCurationSchema), CurationController.updateCuration); //큐레이션 수정
+router.delete('/:curationId', validateRequest(deleteCurationSchema), CurationController.deleteCuration); //큐레이션 삭제
 
 router.post('/:curationId/comments', validateRequest(createCommentSchema), CommentController.createComment); // 답글 등록
 

--- a/src/routes/style-route.js
+++ b/src/routes/style-route.js
@@ -10,6 +10,7 @@ import {
   createCurationSchema, 
   getCurationListSchema
 } from '../middlewares/dto-middleware.js';
+import { hashPasswordMiddleware } from '../middlewares/bcrypt-middleware.js';
 
 const router = Router();
 
@@ -19,7 +20,7 @@ router.get('/:styleId', validateRequest(getStyleDetailSchema), StyleController.g
 router.put('/:styleId', validateRequest(updateStyleSchema), StyleController.updateStyle);          // 수정
 router.delete('/:styleId', validateRequest(deleteStyleSchema), StyleController.deleteStyle);       // 삭제
 
-router.post('/:styleId/curations', validateRequest(createCurationSchema), StyleController.createCuration);
+router.post('/:styleId/curations', validateRequest(createCurationSchema), hashPasswordMiddleware, StyleController.createCuration);
 router.get('/:styleId/curations', validateRequest(getCurationListSchema), StyleController.getCurationList);
 
 export default router;


### PR DESCRIPTION
## 변경 내용

* `createCurationService`:
    * 스타일 존재 여부 확인 후 `404 Not Found` 에러 처리 추가.
    * 비밀번호 해시 여부 판단 로직 추가 및 `hashPassword`를 이용한 비밀번호 해싱 적용. (이미 해시된 경우 재해싱 방지)
* `updateCurationService`, `deleteCurationService`:
    * 큐레이팅 존재 여부 확인 후 `404 Not Found` 에러 처리 추가.
    * `comparePassword`를 이용한 비밀번호 일치 여부 확인 로직 적용 및 `403 Forbidden` 에러 처리 추가.
* `getCurationListService`:
    * 페이지네이션 및 검색 조건에 대한 `400 Bad Request`, `404 Not Found` 에러 처리 추가.
    * 큐레이팅 조회 시 연관된 스타일 정보(`style`)를 `include`하도록 수정. (Prisma `include` 옵션 활용)
* `CurationController`:
    * 모든 API(생성, 조회, 수정, 삭제)에서 `req.params`, `req.body`, `req.query` 대신 `req.validated.params`, `req.validated.body`, `req.validated.query` 사용하도록 변경.
    * 컨트롤러 내 수동 에러 처리 로직 제거 및 전역 에러 핸들러로 에러 처리 위임.
* 라우터(`style-routes.js`, `curation-routes.js`):
    * `POST /styles/:styleId/curations` 라우트에 `hashPasswordMiddleware` 추가.
    * `PUT /curations/:curationId` 및 `DELETE /curations/:curationId` 라우트에 `validateRequest(스키마)` 미들웨어 적용.

## 이유

- 클라이언트 요청 데이터의 유효성을 백엔드 진입점에서부터 철저히 검증하여, 유효하지 않거나 악의적인 데이터가 데이터베이스에 저장되는 것을 방지합니다.
- 비밀번호를 안전하게 해시하여 저장하고, 수정/삭제 시 올바른 비밀번호로만 접근이 가능하도록 하여 무단 변경/삭제를 차단합니다.
- 서비스 레이어에서 발생하는 비즈니스 로직 에러에 HTTP 상태 코드를 직접 부여하여 전역 에러 핸들러가 통일된 방식으로 클라이언트에 응답하도록 합니다.
- 큐레이팅 목록 조회 시 연관 스타일 정보를 함께 제공하여 프론트엔드에서 추가 요청 없이 데이터를 활용할 수 있도록 개선합니다.

## 참고사항

* `hash-password.js`와 `compare-password.js` 파일의 임포트 경로 확인.
* 전역 에러 핸들러 미들웨어(`app.js` 또는 `index.js`에 설정)가 `error.statusCode`를 올바르게 처리하는지 확인 필요.

## 관련 이슈

- close #257